### PR TITLE
Use Python terminology for functions

### DIFF
--- a/latex/hw_mt.tex
+++ b/latex/hw_mt.tex
@@ -104,16 +104,16 @@ Angle $\phi$ is measured from $\bxh$, and angle $\theta$ is measured from $\bzh$
 \item (0.1) Write down the matrix entries for $\bR_y(\rotangA)$. Check that $\bR_y(90^\circ)(1,0,0) = (0,0,-1)$.
 \end{enumerate}
 
-\item (0.5) Write a function \verb+myrotmat.py+ that inputs a rotation angle $\rotangA$ and an index for the axis ($k = 1,2,3$ for $x,y,z$), and then outputs the rotation matrix $\bR_k(\rotangA)$. 
+\item (0.5) Write a function \verb+myrotmat()+ that inputs a rotation angle $\rotangA$ and an index for the axis ($k = 1,2,3$ for $x,y,z$), and then outputs the rotation matrix $\bR_k(\rotangA)$. 
 
 List the computer output for $\bR_x(60^\circ)$, $\bR_y(60^\circ)$, and $\bR_z(60^\circ)$.
 
-The top lines of your \verb+myrotmat.py+ should look like this:
+The top lines of your function definition should look like this:
 %
 \begin{verbatim}
 import numpy as np
 
-def rotmat(xdeg,ixyz):
+def myrotmat(xdeg, ixyz):
 \end{verbatim}
 
 \item (1.5) \refFig{fig:rotsub} shows a rotation of $\rotangB = 30^\circ$ about rotation axis $\rotvec$, which points in the direction represented by polar angle $\theta$ and azimuthal angle $\phi$. The six-part ball is used to help you see the rotation. Mathematically the net rotation is $\bU(\rotvec(\phi,\theta),\rotangB)$. Make sure that \refFig{fig:rotsub} makes sense before proceeding.
@@ -128,10 +128,10 @@ Do not use the words clockwise or counterclockwise.
 %Hint: What operations should be applied to $\rotvec$?
 \end{enumerate}
 
-\item (0.8) Write a new function \verb+myrotmat_gen.py+ that represents $\bU(\rotvec,\rotangB)$; note that this function will call your \verb+myrotmat.py+ function. WARNING: If you use the arctangent function, be sure to use \verb+atan2(y,x)+, not \verb+atan(y/x)+.
+\item (0.8) Write a new function \verb+myrotmat_gen()+ that represents $\bU(\rotvec,\rotangB)$; note that this function will call your \verb+myrotmat()+ function. WARNING: If you use the arctangent function, be sure to use \verb+atan2(y,x)+, not \verb+atan(y/x)+.
 %
 \begin{enumerate}
-\item (0.2) Using \verb+myrotmat_gen.py+, compute $\bU(\rotvec,\rotangB)$ for input values of $\rotvec = (2,1,2)$ and $\rotangB = 30^\circ$. List $\bU$ in decimal form.
+\item (0.2) Using \verb+myrotmat_gen()+, compute $\bU(\rotvec,\rotangB)$ for input values of $\rotvec = (2,1,2)$ and $\rotangB = 30^\circ$. List $\bU$ in decimal form.
 \item (0.1) Numerically check that $\bU(-\rotvec,-\rotangB)$ gives the same result, and explain why this is the case.
 \item (0.1) Numerically check that $\bU(\rotvec,\rotangB)\rotvec = \rotvec$, and explain why this is the case.
 \item (0.2) Numerically check that $\bU$ is orthogonal and also a (right-handed) rotation matrix.
@@ -144,7 +144,7 @@ Do not use the words clockwise or counterclockwise.
 \end{itemize}
 \end{enumerate}
 %
-In Problem 2, you will need to use an accurate version of \verb+myrotmat_gen.py+. You can check your function with the following output:
+In Problem 2, you will need to use an accurate version of \verb+myrotmat_gen()+. You can check your function with the following output:
 %
 \begin{spacing}{1.0}
 \begin{verbatim}
@@ -181,9 +181,9 @@ U =
 %
 {\bf If you get these results, then you did it! If not, then ask me for this function to use in Problem~2. (But you will lose 1.0 point for this request.)}
 
-\item (0.4) Using the function \verb+globefun3.py+, plot your rotation axis $\rotvec$, the initial point $\br_0$, and the rotated point $\br$, all within the same figure. Pencil in an arrow from $\br_0$ to $\br$.
+\item (0.4) Using the function \verb+globefun3()+ found in \verb+globefun3.py+ (\verb+from globefun3 import globefun3+), plot your rotation axis $\rotvec$, the initial point $\br_0$, and the rotated point $\br$, all within the same figure. Pencil in an arrow from $\br_0$ to $\br$.
 
-Note that \verb+globefun3.py+ inputs latitude ($=90-\theta$) and longitude ($=\phi$).
+Note that \verb+globefun3()+ inputs latitude ($=90-\theta$) and longitude ($=\phi$).
 
 \end{enumerate}
 
@@ -199,7 +199,7 @@ Note that \verb+globefun3.py+ inputs latitude ($=90-\theta$) and longitude ($=\p
 
 You should not use any notation such as $\bxh$, $\byh$, or $\bzh$ throughout this problem.
 
-\item You will utilize the function $\bU(\rotvec,\rotangB)$ (\verb+myrotmat_gen.py+) that you obtained in Problem 1. (You should have checked that your function gets the results in Problem 1-5; otherwise get a version of \verb+myrotmat_gen.py+ from me.)
+\item You will utilize the function $\bU(\rotvec,\rotangB)$ (\verb+myrotmat_gen()+) that you obtained in Problem 1. (You should have checked that your function gets the results in Problem 1-5; otherwise get a version of \verb+myrotmat_gen()+ from me.)
 
 \item The dip is denoted by $\theta$. (In Problem 1, $\theta$ was a generic polar angle.)
 
@@ -256,7 +256,7 @@ Please note the following:
 
 %-----------
 
-\item (0.6) Using your \verb+myrotmat_gen.py+, compute the vectors $\bK$, $\bN$, and $\bS$ for this example, using the angles listed in \refFig{fig:cmt}.
+\item (0.6) Using your \verb+myrotmat_gen()+ function, compute the vectors $\bK$, $\bN$, and $\bS$ for this example, using the angles listed in \refFig{fig:cmt}.
 %
 \begin{enumerate}
 \item (0.3) Write the vectors in decimal form as a sum of weighted basis vectors: for example, $\bv = (1.45,1.75,-5.32)$ in basis $\{\bih,\bjh,\bkh\}$ is $\rotvec = 1.45\bih + 1.75\bjh - 5.32\bkh$.


### PR DESCRIPTION
This PR updates `hw_mt.tex` to differentiate between Python files (which can contain code, functions, or both) and the names of actual functions, which are usually denoted by e.g. `generate_kittens()` — note the open parentheses. The idea is to make it more clear to students new to Python where functions are created and stored.

Students should be able to define `myrotmat()` in a new code cell in a notebook without having to create a `.py` file (unless, of course, this is desired for another reason). If they did create a separate `myrotmat.py` file containing the definition for `rotmat()`, then to use their function in the notebook they need to ensure that the file is in the same directory as the notebook, and then use
```python
from myrotmat import rotmat
```
to access. I made some changes to this end for the case of `globefun3.py` and `globefun3()`.

Note that I'm not sure if I got the function names right (e.g. is there a "my" prefix or not?) so if folks decide to merge, please review first. Also happy to discuss more!